### PR TITLE
FIX: strokeWidth bar shifting bug

### DIFF
--- a/public/javascripts/draw.js
+++ b/public/javascripts/draw.js
@@ -450,7 +450,8 @@ var Canvas = React.createClass({
 						<li><Button setTool={this.clearCanvas} tool={"Clear Canvas"} /></li>
 						<li><Button input id ="svgFile" type ="file" name = "svgFile" setTool={this.sendSVG} icon={"icon-publish"} tool={'Import SVG'}/></li>
 						<li><input id="upload" type="file" name="upload" style={{visibility: 'hidden'}} setTool={this.sendSVG}/><br /></li>
-						<li><span>Stroke Width: {this.state.strokeWidth} </span><input type="range" value={this.state.strokeWidth} min="1" max="50" onChange={this.setStrokeWidth} /></li>
+						<li><input type="range" value={this.state.strokeWidth} min="1" max="50" onChange={this.setStrokeWidth}/></li>
+						<li><span>Stroke Width: {this.state.strokeWidth}</span></li>
 					</ul>
 				</div>
 				<div id="canvasDiv">


### PR DESCRIPTION
Split the slider bar and the text for strokeWidth into two separate lines to prevent the shifting bug where the slider moves over each time a new digit is added to the strokewidth value (i.e. when going from a strokeWidth of 9 to 10)

CC: @adeaver 
